### PR TITLE
Fix Pivot subsystem to use conversion factor

### DIFF
--- a/src/main/java/frc/robot/RobotConstants.java
+++ b/src/main/java/frc/robot/RobotConstants.java
@@ -295,7 +295,7 @@ public final class RobotConstants {
 
   public static interface PIVOT {
     public static final double UPPER_SOFT_LIMIT_DEG = 86;
-    public static final double LOWER_SOFT_LIMIT_DEG = 2;
+    public static final double LOWER_SOFT_LIMIT_DEG = 1;
     public static final double PIVOT_CONVERSION_FACTOR = 2.4;
     public static final double SHOOT_AMP_POSITION_DEG = 3;
     public static final double POSITION_TOLERANCE_DEG = 2;

--- a/src/main/java/frc/robot/subsystems/pivot/PivotSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/pivot/PivotSubsystem.java
@@ -22,17 +22,19 @@ public class PivotSubsystem extends EntechSubsystem<PivotInput, PivotOutput> {
   private CANSparkMax pivotLeft;
   private CANSparkMax pivotRight;
 
+  public static double calculateMotorPositionFromDegrees(double degrees){
+    return degrees / RobotConstants.PIVOT.PIVOT_CONVERSION_FACTOR;
+  }
+
   @Override
   public void initialize() {
     if (ENABLED) {
+      //IMPORTANT! DO NOT BURN FLASH OR SET SETTINGS FOR THIS SUBSYSTEM in code!
+      //we want to avoid accidently disabling the controller soft limits
       pivotLeft = new CANSparkMax(RobotConstants.PORTS.CAN.PIVOT_A, MotorType.kBrushless);
       pivotRight = new CANSparkMax(RobotConstants.PORTS.CAN.PIVOT_B, MotorType.kBrushless);
       pivotRight.follow(pivotLeft);
 
-      pivotLeft.getEncoder()
-          .setPositionConversionFactor(RobotConstants.PIVOT.PIVOT_CONVERSION_FACTOR);
-      pivotRight.getEncoder()
-          .setPositionConversionFactor(RobotConstants.PIVOT.PIVOT_CONVERSION_FACTOR);
 
       updateBrakeMode();
 
@@ -78,7 +80,7 @@ public class PivotSubsystem extends EntechSubsystem<PivotInput, PivotOutput> {
     double clampedPosition = clampRequestedPosition(currentInput.getRequestedPosition());
     if (ENABLED) {
       if (currentInput.getActivate()) {
-        pivotLeft.getPIDController().setReference(clampedPosition, ControlType.kPosition);
+        pivotLeft.getPIDController().setReference(calculateMotorPositionFromDegrees(clampedPosition), ControlType.kPosition);
         updateBrakeMode();
       }
     }

--- a/src/test/java/frc/robot/subsystems/TestPivotSubsystem.java
+++ b/src/test/java/frc/robot/subsystems/TestPivotSubsystem.java
@@ -1,0 +1,20 @@
+package frc.robot.subsystems;
+
+import frc.robot.subsystems.pivot.PivotSubsystem;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class TestPivotSubsystem {
+
+  public static final double TOLERANCE = 0.00001;
+
+  @Test
+  public void testPivotConversion(){
+    assertEquals(30.0, PivotSubsystem.calculateMotorPositionFromDegrees(72.0), TOLERANCE);
+  }
+
+
+
+}


### PR DESCRIPTION
This fixes the conversion to work properly with smart motion.
The sparkmax conversion factors should NOT be used-- we need to do it ourself